### PR TITLE
addDependencyTo option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,13 @@ posthtml()
 __root__: Root folder path for include. Default `./`
 
 __encoding__: Default `utf-8`
+
+__addDependencyTo__: An object with addDependency() method, taking file path as an argument. Called whenever a file is included. Default `null`. You can use it for hot-reloading in webpack posthtml-loader like this:
+
+```javascript
+posthtml: function(webpack) {
+  return [
+    require('posthtml-include')({ addDependencyTo: webpack })
+  ]
+}
+```

--- a/index.js
+++ b/index.js
@@ -11,7 +11,15 @@ module.exports = function(options) {
         tree.match({ tag: 'include' }, function(node) {
             var src = node.attrs.src || false,
                 content;
-            if (src) content = parser(fs.readFileSync(path.resolve(options.root, src), options.encoding));
+            if (src) {
+                src = path.resolve(options.root, src);
+                content = parser(fs.readFileSync(src, options.encoding));
+
+                if (typeof options.addDependencyTo === 'object' &&
+                    typeof options.addDependencyTo.addDependency === 'function') {
+                    options.addDependencyTo.addDependency(src);
+                }
+            }
             return {
                 tag: false,
                 content: content

--- a/test/test.js
+++ b/test/test.js
@@ -33,4 +33,21 @@ describe('Simple test', function() {
             done
         );
     });
+
+    it('addDependencyTo option', function(done) {
+        var includePath = require('path').resolve('./test/blocks/button/button.html');
+
+        function test(filePath) {
+            try {
+                expect(filePath).to.eql(includePath);
+                done();
+            } catch(err) {
+                done(err);
+            }
+        }
+
+        posthtml()
+            .use(plugin({ addDependencyTo: { addDependency: test }}))
+            .process('<include src="./test/blocks/button/button.html">');
+    });
 });


### PR DESCRIPTION
Add `addDependencyTo` option like the one in `postcss-imports` to make webpack (or other tools) aware of included files in order for hot reloading to work properly.