### PR TITLE
allow delimeter specification

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,8 +20,13 @@ module.exports = (options = {}) => {
       let content;
       let subtree;
       let source;
-      let locals = false;
-      const delimiters = options.delimiters || ['{{', '}}'];
+      const posthtmlExpressionsOptions = {
+        locals: false,
+      }
+
+      if (options.delimiters) {
+        posthtmlExpressionsOptions.delimiters = options.delimiters;
+      }
 
       if (src) {
         src = path.resolve(options.root, src);
@@ -29,12 +34,12 @@ module.exports = (options = {}) => {
 
         try {
           const localsRaw = node.attrs.locals || (node.content ? node.content.join().replace(/\n/g, '') : false);
-          locals = JSON.parse(localsRaw);
+          posthtmlExpressionsOptions.locals = JSON.parse(localsRaw);
         } catch {}
 
-        if (locals) {
+        if (posthtmlExpressionsOptions.locals) {
           const result = posthtml()
-            .use(expressions({locals, delimiters}))
+            .use(expressions(posthtmlExpressionsOptions))
             .process(source, {sync: true});
           source = result.html;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ module.exports = (options = {}) => {
       let subtree;
       let source;
       let locals = false;
-      let delimiters =  options.delimiters || ['{{','}}'];
+      const delimiters = options.delimiters || ['{{', '}}'];
 
       if (src) {
         src = path.resolve(options.root, src);

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ module.exports = (options = {}) => {
       let subtree;
       let source;
       const posthtmlExpressionsOptions = {
-        locals: false,
+        locals: false
       }
 
       if (options.delimiters) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ module.exports = (options = {}) => {
       let subtree;
       let source;
       let locals = false;
+      let delimiters =  options.delimiters || ['{{','}}'];
 
       if (src) {
         src = path.resolve(options.root, src);
@@ -33,7 +34,7 @@ module.exports = (options = {}) => {
 
         if (locals) {
           const result = posthtml()
-            .use(expressions({locals}))
+            .use(expressions({locals, delimiters}))
             .process(source, {sync: true});
           source = result.html;
         }


### PR DESCRIPTION
Posthtml-include uses [posthtml-expressions](https://github.com/posthtml/posthtml-expressions) to detect local variables passed into include blocks. The default variable syntax for posthtml-expressions is {{ my_variable }}. However, many JavaScript frameworks use `{{` and `}}` as expression delimiters for their own uses which would clash with posthtml-expression's variable injection. posthtml-expressions allows for the [configuartion of variable delimiters](https://github.com/posthtml/posthtml-expressions#options) to solve this.

This change allows for the passing in of a delimiter option that will get passed to posthtml-expressions. This lets us change the delimter that's used for variables in out includes.