### PR TITLE
doc: Fix `posthtml-include` name from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ __components/button.html__
 const { readFileSync } = require('fs')
 
 const posthtml = require('posthtml')
-const include = require('include')
+const include = require('posthtml-include')
 
 const html = readFileSync('index.html')
 


### PR DESCRIPTION
Fix npm module name on README example.