### PR TITLE
add array to pass options to expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ __root__: Root folder path for include. Default `./`
 
 __encoding__: Default `utf-8`
 
+__posthtmlExpressionsOptions__: Array to pass options posthtml-expression
+
 ### Component options
 __locals__: Object containing any local variables that you want to be accessible inside the include component
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,9 +20,8 @@ module.exports = (options = {}) => {
       let content;
       let subtree;
       let source;
-      const posthtmlExpressionsOptions = {
-        locals: false
-      }
+      const posthtmlExpressionsOptions = options.posthtmlExpressionsOptions || {locals: false};
+
 
       if (options.delimiters) {
         posthtmlExpressionsOptions.delimiters = options.delimiters;

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,6 @@ module.exports = (options = {}) => {
       let source;
       const posthtmlExpressionsOptions = options.posthtmlExpressionsOptions || {locals: false};
 
-
       if (options.delimiters) {
         posthtmlExpressionsOptions.delimiters = options.delimiters;
       }


### PR DESCRIPTION
since we don't want to pass empty values in our include statement, we need posthtml-expressions with strictMode: false.
For that we now have an option to pass options to posthtml-expression