### PR TITLE
Add dependency messages for nested includes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,7 @@ module.exports = (options = {}) => {
         subtree = tree.parser(source);
         subtree.match = tree.match;
         subtree.parser = tree.parser;
+        subtree.messages = tree.messages;
         content = source.includes('include') ? posthtmlInclude(subtree) : subtree;
 
         if (tree.messages) {


### PR DESCRIPTION
If an included file also has dependencies, they are not currently propagated back to the root. This means that watch mode doesn't pick up changes to nested files. The fix is to propagated the tree's `messages` array to the subtree.