### PR TITLE
Fix: multiple `<include>` tag with global locals evaluate locals uncorrectry

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ module.exports = (options = {}) => {
       let content;
       let subtree;
       let source;
-      const posthtmlExpressionsOptions = options.posthtmlExpressionsOptions || {locals: false};
+      let posthtmlExpressionsOptions = options.posthtmlExpressionsOptions || {locals: false};
       if (options.delimiters) {
         posthtmlExpressionsOptions.delimiters = options.delimiters;
       }
@@ -32,7 +32,10 @@ module.exports = (options = {}) => {
         try {
           const localsRaw = node.attrs.locals || (node.content ? node.content.join().replace(/\n/g, '') : false);
           const localsJson = JSON.parse(localsRaw);
-          posthtmlExpressionsOptions.locals = posthtmlExpressionsOptions.locals ? Object.assign(localsJson, posthtmlExpressionsOptions.locals) : localsJson;
+          posthtmlExpressionsOptions = {
+            ...posthtmlExpressionsOptions,
+            locals: posthtmlExpressionsOptions.locals ? Object.assign(localsJson, posthtmlExpressionsOptions.locals) : localsJson
+          };
         } catch {}
 
         if (posthtmlExpressionsOptions.locals) {

--- a/test/expected/multiple-include.html
+++ b/test/expected/multiple-include.html
@@ -1,0 +1,14 @@
+<div>local1</div>
+<div>global</div>
+
+<div>local2</div>
+<div>global</div>
+
+<div>local3</div>
+<div>global</div>
+
+<div>local4</div>
+<div>global</div>
+
+<div>local5</div>
+<div>global</div>

--- a/test/fixtures/multiple-include.html
+++ b/test/fixtures/multiple-include.html
@@ -1,0 +1,5 @@
+<include src="./test/fixtures/includes/6.html">{ "localVariable": "local1" }</include>
+<include src="./test/fixtures/includes/6.html">{ "localVariable": "local2" }</include>
+<include src="./test/fixtures/includes/6.html">{ "localVariable": "local3" }</include>
+<include src="./test/fixtures/includes/6.html">{ "localVariable": "local4" }</include>
+<include src="./test/fixtures/includes/6.html">{ "localVariable": "local5" }</include>

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 const test = require('ava')
-const plugin = require('../lib')
+const plugin = require('../lib/index.js')
 const posthtml = require('posthtml')
 
 const path = require('path')

--- a/test/test.js
+++ b/test/test.js
@@ -60,6 +60,13 @@ test('Should merge global locals', t => {
     }})
 })
 
+test('Should merge global variables and evaluate each local variable', t => {
+  return process(t, 'multiple-include', {
+    posthtmlExpressionsOptions: {
+      locals: {globalVariable: 'global'}
+    }})
+})
+
 test('addDependency message', t => {
   const includePath = require('path').resolve('./test/fixtures/blocks/button/button.html')
 


### PR DESCRIPTION
## Overview

Hi, there!

I run into a case that using `<include>` tag multiple times with locals defined globally causes uncorrect evaluation for locals. This PR is a patch for that case.

### Example

```html
<!-- parts.html -->
<div>{{ foo }}</div>
```

```html
<include src="parts.html" locals='{ "foo": 1 }'></include>
<include src="parts.html" locals='{ "foo": 2 }'></include>
```

↓

```html
<!-- expected -->
<div>1</div>
<div>2</div>
```

```html
<!-- actual -->
<div>1</div>
<div>1</div>
```

(See also `test/expected/multiple-include.html`.)

## Points to change

- fix merged `locals` options for posthtml-expressions & add test cases
- fix xo error for missing extension (`../lib` → `../lib/index.js`)

## issues

fix #74
