### PR TITLE
fix: merging issue with global local prop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ module.exports = (options = {}) => {
           const localsJson = JSON.parse(localsRaw);
           posthtmlExpressionsOptions = {
             ...posthtmlExpressionsOptions,
-            locals: posthtmlExpressionsOptions.locals ? Object.assign(posthtmlExpressionsOptions.locals, localsJson) : localsJson
+            locals: posthtmlExpressionsOptions.locals ? {...posthtmlExpressionsOptions.locals, ...localsJson} : localsJson
           };
         } catch {}
 


### PR DESCRIPTION
The intent of this PR is to address an issue when using `posthtml-include` plugin on a page with several `<include />` blocks.

**Problem:**

I noticed some values were being persisted across different includes, creating a larger `locals` object file, even though the component doesn't send any locals at all.

An example to illustrate the issue:

```html
<!-- a.html-->
<p>Text value is: <strong>{{  props.text || "none" }}</strong></p>
```

```html
<include src="./a.html">{ "props": { text: "Lorem Ipsum" } }</include>

<include src="./a.html"></include>
```

Generated ouput:

```html
<p>Text value is: <strong>Lorem Ipsum</strong></p>

<p>Text value is: <strong>Lorem ipsum</strong></p>
```

Basically, the culprit is the `Object.assign` call here: https://github.com/posthtml/posthtml-include/blob/69789e2c99f33f135418d3ee64c061fa1c76faa2/lib/index.js#L37

The method call is basically copying `localsJson` inside the global locals object. And that is not the desired effect, I suppose.

The fix was simple, I basically updated this faulty line to use object propagation to merge global locals with object scoped locals into a new object. https://github.com/posthtml/posthtml-include/blob/f46914a79e89fafb714a359b7a2498a97a50aabf/lib/index.js#L37

Generated output:

```html
<p>Text value is: <strong>Lorem Ipsum</strong></p>

<p>Text value is: <strong>none</strong></p>
```

**Notes:**

* I could have passed an empty object as the first parameter to `Object.assign`, that would have solved this problem too. Let me know if you prefer this approach instead.
* Case you prefer, I can create a reproduction repo for this bug. But the examples provided should be enough to illustrate the situation
