### PR TITLE
breaking: add cwd property to complement root

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ posthtml([ include({ encoding: 'utf8' }) ])
 
 ### Options
 
-__root__: Root folder path for include. Default `./`
+__root__: Root directory for include. Default `process.cwd()`
+
+__cwd__: Current working directory for include. Default `process.cwd()`
 
 __encoding__: Default `utf-8`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,16 +2,25 @@
 
 const fs = require('fs');
 const path = require('path');
+const process = require('process');
 const posthtml = require('posthtml');
 const {parser} = require('posthtml-parser');
 const {match} = require('posthtml/lib/api');
 const expressions = require('posthtml-expressions');
 
 module.exports = (options = {}) => {
-  options.root = options.root || './';
+  options.root = options.root
+    ? path.resolve(options.root)
+    : process.cwd();
   options.encoding = options.encoding || 'utf-8';
 
   return function posthtmlInclude(tree) {
+    const cwd = options.cwd
+      ? path.resolve(options.cwd)
+      : tree.options.from
+        ? path.dirname(path.resolve(tree.options.from))
+        : process.cwd()
+
     tree.parser = tree.parser || parser;
     tree.match = tree.match || match;
 
@@ -26,7 +35,9 @@ module.exports = (options = {}) => {
       }
 
       if (src) {
-        src = path.resolve(options.root, src);
+        src = path.isAbsolute(src)
+          ? path.join(options.root, src)
+          : path.resolve(cwd, src)
         source = fs.readFileSync(src, options.encoding);
 
         try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,12 @@ module.exports = (options = {}) => {
         }
 
         subtree = tree.parser(source);
+        subtree.options = subtree.options || {};
+        subtree.options.from = path.isAbsolute(src)
+            ? src
+            : tree.options.from
+              ? path.relative(tree.options.from, src)
+              : src;
         subtree.match = tree.match;
         subtree.parser = tree.parser;
         subtree.messages = tree.messages;


### PR DESCRIPTION
Problems:

* Absolute paths are _always_ relative to the system root. So, for example, `/file` doesn't mean the `file` in `options.root`, but `/file` on the system.
* Paths aren't relative to individual files. For example, in `folder/file.html` and `folder/child/file.html`, with `root` set to `folder`, the path `file.txt` is always `folder/file.txt` instead of `folder/child/file.txt` for the second.

Solution:

* The existing `options.root` is _only_ applied to absolute paths.
* Introduce a separate `options.cwd` parameter which corresponds to the former `options.root`.
* Fall back to using the `from` path from posthtml is `cwd` is unset, only defaulting to the current directory if _that_ isn't set.

Notes:

* This is a breaking change, but I can't imagine a way of making this that _wouldn't_ be breaking. We could make `root` really be cwd and give some other name for `root`, but this would be too confusing imho.